### PR TITLE
GitHub ActionsでGitHub PagesにDeployする

### DIFF
--- a/.github/workflows/publish_gh_pages.yml
+++ b/.github/workflows/publish_gh_pages.yml
@@ -1,0 +1,30 @@
+name: Publish GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    branches:
+      - main
+
+jobs:
+  publish_gh_pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: Build page
+        run: |
+          npm ci
+          npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
FIX: #3 

- GitHub Actionsを利用してGitHub PagesにDeployします
- そのために `.github/workflows/publish_gh_pages.yml` というファイルを追加しています