### PR TITLE
VSCodeの推奨拡張機能を共有する

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "oderwat.indent-rainbow",
+    "ms-ceintl.vscode-language-pack-ja",
+    "ms-vsliveshare.vsliveshare",
+    "esbenp.prettier-vscode",
+    "mosapride.zenkaku",
+    "streetsidesoftware.code-spell-checker",
+    "usernamehw.errorlens",
+    "wraith13.bracket-lens",
+    "vscode-icons-team.vscode-icons",
+    "visualstudioexptteam.vscodeintellicode",
+    "VisualStudioExptTeam.intellicode-api-usage-examples"
+  ]
+}


### PR DESCRIPTION
タイトル通り、 `.vscode/extensions.json` という特殊なファイルを置くことで、Visual Studio Codeでの推奨拡張機能をチームで共有できるようにします