### PR TITLE
タスクの説明も表示する

### DIFF
--- a/src/components/task.tsx
+++ b/src/components/task.tsx
@@ -9,6 +9,7 @@ export const TaskView: React.FC<{ task?: Task }> = ({ task }) => {
             <a href={task.html_url} target="_blank">
               {task.title}
             </a>
+            <p>{task.body}</p>
           </h2>
           <div>
             <ul>

--- a/src/types/task.d.ts
+++ b/src/types/task.d.ts
@@ -6,6 +6,7 @@ export type Task = {
   closed_at: string | null;
   title: string;
   state: string;
+  body: string | null;
   assignee: User | null;
   assignees: User[] | [];
   user: User;


### PR DESCRIPTION
fix: #24 

issueの最初のコメントを表示させるようにしてみました。
この対応で下図のような表示になります。

<img src="https://user-images.githubusercontent.com/63393496/202834112-de0174df-b623-4a31-a5ef-08648ebbc8ff.png" width="600px">

この対応の前提として、タスクの説明をissue作成時のコメント欄に書いておく必要があります。
issueのテンプレートを用意するのもいいのではと思っています。
テンプレートを用意することで、issue作成者にどんな情報を書いたらいいのか伝わるのでは思いました。
※参考情報
issueの書き方 → https://gist.github.com/BcRikko/6af0b248148c12d3ab90
issueのテンプレート → https://qiita.com/syo19961113/items/6a3f215cf6f07641c2d7


